### PR TITLE
DB authentication

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       args:
         WEB3SIGNER_VERSION: 24.6.0
         STAKER_SCRIPTS_VERSION: v0.1.0
+        POSTGRES_USER: postgres
     environment:
       JAVA_OPTS: "-Xmx6g"
       EXTRA_OPTS: ""
@@ -33,6 +34,7 @@ services:
       context: services/flyway
       args:
         WEB3SIGNER_VERSION: 24.6.0
+        POSTGRES_USER: postgres
     depends_on:
       postgres:
         condition: service_started
@@ -42,6 +44,8 @@ services:
       context: services/postgres
       args:
         WEB3SIGNER_VERSION: 24.6.0
+        DATA_DIR: /var/lib/postgresql/data
+        POSTGRES_USER: postgres
     user: postgres
     volumes:
       - postgres_data:/var/lib/postgresql/data

--- a/package_variants/gnosis/docker-compose.yml
+++ b/package_variants/gnosis/docker-compose.yml
@@ -28,6 +28,7 @@ services:
 
   postgres:
     build:
+      dockerfile: Dockerfile.debian
       args:
         POSTGRES_PASSWORD: gnosis
         PGPASSWORD: gnosis

--- a/package_variants/gnosis/docker-compose.yml
+++ b/package_variants/gnosis/docker-compose.yml
@@ -9,6 +9,8 @@ services:
     build:
       args:
         NETWORK: gnosis
+        PGPASSWORD: gnosis
+        POSTGRES_DB: web3signer-gnosis
     healthcheck:
       test: >-
         curl -H 'Host: web3signer.web3signer-gnosis.dappnode'
@@ -21,3 +23,12 @@ services:
     build:
       args:
         NETWORK: gnosis
+        PGPASSWORD: gnosis
+        POSTGRES_DB: web3signer-gnosis
+
+  postgres:
+    build:
+      args:
+        POSTGRES_PASSWORD: gnosis
+        PGPASSWORD: gnosis
+        POSTGRES_DB: web3signer-gnosis

--- a/package_variants/holesky/docker-compose.yml
+++ b/package_variants/holesky/docker-compose.yml
@@ -9,6 +9,8 @@ services:
     build:
       args:
         NETWORK: holesky
+        PGPASSWORD: password
+        POSTGRES_DB: web3signer
     healthcheck:
       test: >-
         curl -H 'Host: web3signer.web3signer-holesky.dappnode'
@@ -21,3 +23,12 @@ services:
     build:
       args:
         NETWORK: holesky
+        PGPASSWORD: password
+        POSTGRES_DB: web3signer
+
+  postgres:
+    build:
+      args:
+        POSTGRES_PASSWORD: password
+        PGPASSWORD: password
+        POSTGRES_DB: web3signer

--- a/package_variants/holesky/docker-compose.yml
+++ b/package_variants/holesky/docker-compose.yml
@@ -28,6 +28,7 @@ services:
 
   postgres:
     build:
+      dockerfile: Dockerfile.alpine
       args:
         POSTGRES_PASSWORD: password
         PGPASSWORD: password

--- a/package_variants/lukso/docker-compose.yml
+++ b/package_variants/lukso/docker-compose.yml
@@ -28,6 +28,7 @@ services:
 
   postgres:
     build:
+      dockerfile: Dockerfile.debian
       args:
         POSTGRES_PASSWORD: password
         PGPASSWORD: password

--- a/package_variants/lukso/docker-compose.yml
+++ b/package_variants/lukso/docker-compose.yml
@@ -9,6 +9,8 @@ services:
     build:
       args:
         NETWORK: lukso
+        PGPASSWORD: password
+        POSTGRES_DB: web3signer
     healthcheck:
       test: >-
         curl -H 'Host: web3signer.web3signer-lukso.dappnode'
@@ -21,3 +23,12 @@ services:
     build:
       args:
         NETWORK: lukso
+        PGPASSWORD: password
+        POSTGRES_DB: web3signer
+
+  postgres:
+    build:
+      args:
+        POSTGRES_PASSWORD: password
+        PGPASSWORD: password
+        POSTGRES_DB: web3signer

--- a/package_variants/mainnet/docker-compose.yml
+++ b/package_variants/mainnet/docker-compose.yml
@@ -28,6 +28,7 @@ services:
 
   postgres:
     build:
+      dockerfile: Dockerfile.debian
       args:
         POSTGRES_PASSWORD: password
         PGPASSWORD: password

--- a/package_variants/mainnet/docker-compose.yml
+++ b/package_variants/mainnet/docker-compose.yml
@@ -9,6 +9,8 @@ services:
     build:
       args:
         NETWORK: mainnet
+        PGPASSWORD: password
+        POSTGRES_DB: web3signer
     healthcheck:
       test: >-
         curl -H 'Host: web3signer.web3signer.dappnode'
@@ -21,3 +23,12 @@ services:
     build:
       args:
         NETWORK: mainnet
+        PGPASSWORD: password
+        POSTGRES_DB: web3signer
+
+  postgres:
+    build:
+      args:
+        POSTGRES_PASSWORD: password
+        PGPASSWORD: password
+        POSTGRES_DB: web3signer

--- a/services/flyway/Dockerfile
+++ b/services/flyway/Dockerfile
@@ -9,9 +9,16 @@ RUN apk --no-cache add git && \
 FROM flyway/flyway:9.16.1-alpine
 
 ARG NETWORK
+ARG PGPASSWORD
+ARG POSTGRES_DB
+ARG POSTGRES_USER
+
 
 ENV MIGRATIONS_DIR=/flyway/sql \
-    NETWORK=${NETWORK}
+    NETWORK=${NETWORK} \
+    PGPASSWORD=${PGPASSWORD} \
+    POSTGRES_DB=${POSTGRES_DB} \
+    POSTGRES_USER=${POSTGRES_USER}
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 

--- a/services/flyway/entrypoint.sh
+++ b/services/flyway/entrypoint.sh
@@ -16,7 +16,8 @@ fi
 set -e
 
 # Get postgresql database version and trim whitespaces
-DATABASE_VERSION=$(PGPASSWORD=password psql -U postgres -h "${POSTGRES_DOMAIN}" -p 5432 -d web3signer -t -A -c "SELECT version FROM database_version WHERE id=1;")
+# PGPASSWORD=${PGPASSWORD}
+DATABASE_VERSION=$(psql -U postgres -h "${POSTGRES_DOMAIN}" -p 5432 -d "${POSTGRES_DB}" -t -A -c "SELECT version FROM database_version WHERE id=1;")
 
 # Get the latest migration file version (ending in .sql) and trim whitespaces
 LATEST_MIGRATION_VERSION=$(ls -1 /flyway/sql/ | grep -E "V[0-9]+__.*.sql$" | tail -n 1 | cut -d'_' -f1 | cut -d'V' -f2 | sed 's/^0*//' | tr -d '[:space:]')
@@ -35,7 +36,7 @@ if [ "$DATABASE_VERSION" -ge "$LATEST_MIGRATION_VERSION" ]; then
   exit 0
 else
   echo "[INFO - entrypoint] Database version is less than the latest migration file version. Migrating..."
-  flyway -baselineOnMigrate="true" -baselineVersion="${DATABASE_VERSION}" -url="jdbc:postgresql://${POSTGRES_DOMAIN}:5432/web3signer" -user=postgres -password=password -connectRetries=60 migrate
+  flyway -baselineOnMigrate="true" -baselineVersion="${DATABASE_VERSION}" -url="jdbc:postgresql://${POSTGRES_DOMAIN}:5432/web3signer" -user="${POSTGRES_USER}" -password="${PGPASSWORD}" -connectRetries=60 migrate
   echo "[INFO - entrypoint] Migration completed"
   exit 0
 fi

--- a/services/postgres/Dockerfile
+++ b/services/postgres/Dockerfile
@@ -6,19 +6,34 @@ WORKDIR /usr/src/app
 RUN apk --no-cache add git && \
     git clone --depth 1 --branch ${WEB3SIGNER_VERSION} https://github.com/ConsenSys/web3signer.git
 
-FROM postgres:14.1-alpine3.15
+#FROM postgres:14.1-alpine3.15
 
-ENV POSTGRES_PASSWORD=password \
-    PGPASSWORD=password \
-    POSTGRES_USER=postgres \ 
-    POSTGRES_DB=web3signer \
+FROM postgres:14.1-bullseye
+
+ARG POSTGRES_PASSWORD
+ARG PGPASSWORD
+ARG POSTGRES_DB
+ARG POSTGRES_USER
+
+ENV POSTGRES_PASSWORD=${POSTGRES_PASSWORD} \
+    PGPASSWORD=${PGPASSWORD} \
+    POSTGRES_USER=${POSTGRES_USER} \
+    POSTGRES_DB=${POSTGRES_DB} \
     INITDB_DIR=/docker-entrypoint-initdb.d/
 
 COPY rename_files.sh /usr/local/bin/rename_files.sh
+#COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 COPY --from=migrations-download /usr/src/app/web3signer/slashing-protection/src/main/resources/migrations/postgresql/* ${INITDB_DIR}
+
+# RUN apk --no-cache add sudo && \
+#     adduser postgres root && \
+#     echo "postgres ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+#RUN chmod +x /usr/local/bin/rename_files.sh /usr/local/bin/entrypoint.sh && /usr/local/bin/rename_files.sh
 
 RUN chmod +x /usr/local/bin/rename_files.sh && /usr/local/bin/rename_files.sh
 
 USER postgres
 
-CMD ["postgres"]
+#ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]
+CMD [ "postgres" ]

--- a/services/postgres/Dockerfile.alpine
+++ b/services/postgres/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM alpine:3.15.10 as migrations-download
+FROM alpine:3.15.0 as migrations-download
 ARG WEB3SIGNER_VERSION
 WORKDIR /usr/src/app
 
@@ -6,9 +6,7 @@ WORKDIR /usr/src/app
 RUN apk --no-cache add git && \
     git clone --depth 1 --branch ${WEB3SIGNER_VERSION} https://github.com/ConsenSys/web3signer.git
 
-#FROM postgres:14.1-alpine3.15
-
-FROM postgres:14.1-bullseye
+FROM postgres:14.1-alpine3.15
 
 ARG POSTGRES_PASSWORD
 ARG PGPASSWORD
@@ -22,18 +20,6 @@ ENV POSTGRES_PASSWORD=${POSTGRES_PASSWORD} \
     INITDB_DIR=/docker-entrypoint-initdb.d/
 
 COPY rename_files.sh /usr/local/bin/rename_files.sh
-#COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 COPY --from=migrations-download /usr/src/app/web3signer/slashing-protection/src/main/resources/migrations/postgresql/* ${INITDB_DIR}
 
-# RUN apk --no-cache add sudo && \
-#     adduser postgres root && \
-#     echo "postgres ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
-
-#RUN chmod +x /usr/local/bin/rename_files.sh /usr/local/bin/entrypoint.sh && /usr/local/bin/rename_files.sh
-
 RUN chmod +x /usr/local/bin/rename_files.sh && /usr/local/bin/rename_files.sh
-
-USER postgres
-
-#ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]
-CMD [ "postgres" ]

--- a/services/postgres/Dockerfile.debian
+++ b/services/postgres/Dockerfile.debian
@@ -1,0 +1,25 @@
+FROM alpine:3.15.0 as migrations-download
+ARG WEB3SIGNER_VERSION
+WORKDIR /usr/src/app
+
+# Copy files in branch ${WEB3SIGNER_VERSION} from web3signer repository
+RUN apk --no-cache add git && \
+    git clone --depth 1 --branch ${WEB3SIGNER_VERSION} https://github.com/ConsenSys/web3signer.git
+
+FROM postgres:14.1-bullseye
+
+ARG POSTGRES_PASSWORD
+ARG PGPASSWORD
+ARG POSTGRES_DB
+ARG POSTGRES_USER
+
+ENV POSTGRES_PASSWORD=${POSTGRES_PASSWORD} \
+    PGPASSWORD=${PGPASSWORD} \
+    POSTGRES_USER=${POSTGRES_USER} \
+    POSTGRES_DB=${POSTGRES_DB} \
+    INITDB_DIR=/docker-entrypoint-initdb.d/
+
+COPY rename_files.sh /usr/local/bin/rename_files.sh
+COPY --from=migrations-download /usr/src/app/web3signer/slashing-protection/src/main/resources/migrations/postgresql/* ${INITDB_DIR}
+
+RUN chmod +x /usr/local/bin/rename_files.sh && /usr/local/bin/rename_files.sh

--- a/services/web3signer/Dockerfile
+++ b/services/web3signer/Dockerfile
@@ -4,6 +4,9 @@ FROM consensys/web3signer:$WEB3SIGNER_VERSION
 
 ARG NETWORK
 ARG STAKER_SCRIPTS_VERSION
+ARG PGPASSWORD
+ARG POSTGRES_DB
+ARG POSTGRES_USER
 
 USER root
 
@@ -19,6 +22,9 @@ RUN chmod +rx /usr/local/bin/entrypoint.sh /etc/profile.d/common_tools.sh
 
 # This env changes the variant
 # Placed at the end to regenerate the least amount of layers
-ENV NETWORK=${NETWORK}
+ENV NETWORK=${NETWORK} \
+    PGPASSWORD=${PGPASSWORD} \
+    POSTGRES_DB=${POSTGRES_DB} \
+    POSTGRES_USER=${POSTGRES_USER}
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/services/web3signer/entrypoint.sh
+++ b/services/web3signer/entrypoint.sh
@@ -51,9 +51,9 @@ run_web3signer() {
     --idle-connection-timeout-seconds=900 \
     eth2 \
     --network="${NETWORK}" \
-    --slashing-protection-db-url="jdbc:postgresql://postgres.${WEB3SIGNER_DOMAIN}:5432/web3signer" \
-    --slashing-protection-db-username=postgres \
-    --slashing-protection-db-password=password \
+    --slashing-protection-db-url="jdbc:postgresql://postgres.${WEB3SIGNER_DOMAIN}:5432/${POSTGRES_DB}" \
+    --slashing-protection-db-username="${POSTGRES_USER}" \
+    --slashing-protection-db-password="${PGPASSWORD}" \
     --slashing-protection-pruning-enabled=true \
     --slashing-protection-pruning-epochs-to-keep=500 \
     --key-manager-api-enabled=true ${EXTRA_OPTS}


### PR DESCRIPTION
This PR fixes the migration errors due to changing `postgres` base image from `Debian` to `alpine`. Now, each signer package uses the base image it used before migrating to the generic repository.

Also, each package uses its own auth settings.