### PR TITLE
Add staker network fullnodes domains to cors and HTTP allow list

### DIFF
--- a/services/web3signer/entrypoint.sh
+++ b/services/web3signer/entrypoint.sh
@@ -9,8 +9,8 @@ KEYFILES_DIR="/data/keyfiles"
 WEB3SIGNER_DOMAIN=$(get_web3signer_domain "${NETWORK}" "${SUPPORTED_NETWORKS}")
 
 generate_cors_settings() {
-  CORS_ALLOWLIST="web3signer.${WEB3SIGNER_DOMAIN},brain.${WEB3SIGNER_DOMAIN}"
-  CORS_ORIGINS="http://web3signer.${WEB3SIGNER_DOMAIN},http://brain.${WEB3SIGNER_DOMAIN}"
+  CORS_ALLOWLIST="web3signer.${WEB3SIGNER_DOMAIN},brain.${WEB3SIGNER_DOMAIN},signer.${NETWORK}.dncore.dappnode,signer.${NETWORK}.staker.dappnode"
+  CORS_ORIGINS="http://web3signer.${WEB3SIGNER_DOMAIN},http://brain.${WEB3SIGNER_DOMAIN},http://signer.${NETWORK}.dncore.dappnode,http://signer.${NETWORK}.staker.dappnode"
 
   consensus_dnp=$(get_value_from_global_env "CONSENSUS_CLIENT" "${NETWORK}")
 


### PR DESCRIPTION
The brain is using the signer url from the dncore network as URL to be used by the validators services to query the signer. Add staker network fullnodes domains to cors and allow list to avoid 403 errors:
- staker network
- dncore network