### PR TITLE
Polish gha

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,4 +9,4 @@ jobs:
     name: Build test
     steps:
       - uses: actions/checkout@v4
-      - run: npx @dappnode/dappnodesdk build --skip_save --all-variants
+      - run: npx @dappnode/dappnodesdk build --skip_save --all-variants --content_provider=http://10.200.200.7:5001 --eth_provider=https://web3.dappnode.net

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,32 +1,12 @@
-name: "Main"
+name: "Build Test on all networks"
 on:
   pull_request:
-  push:
-    branches:
-      - "master"
-      - "main"
-      - "v[0-9]+.[0-9]+.[0-9]+"
-    paths-ignore:
-      - "README.md"
-      - ".github/workflows/main_test.yml"
+    types: [opened, synchronize, reopened]
 
 jobs:
   build-test:
     runs-on: ubuntu-latest
     name: Build test
-    if: github.event_name != 'push'
     steps:
       - uses: actions/checkout@v4
-      - run: npx @dappnode/dappnodesdk build --skip_save --variant mainnet
-
-  release:
-    name: Release
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push'
-    steps:
-      - uses: actions/checkout@v4
-      - name: Publish
-        run: npx @dappnode/dappnodesdk publish patch --dappnode_team_preset --all-variants
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DEVELOPER_ADDRESS: "0xf35960302a07022aba880dffaec2fdd64d5bf1c1"
+      - run: npx @dappnode/dappnodesdk build --skip_save --all-variants

--- a/.github/workflows/release_on_demand.yml
+++ b/.github/workflows/release_on_demand.yml
@@ -1,4 +1,4 @@
-name: "Main_test"
+name: "Release on Demand"
 on:
   workflow_dispatch:
     inputs:
@@ -38,7 +38,7 @@ jobs:
         with:
           node-version: '22'
       - name: Publish
-        run: npx @dappnode/dappnodesdk publish patch --content_provider=http://10.200.200.7:5001 --eth_provider=https://web3.dappnode.net --variant ${{ matrix.variant }}
+        run: npx @dappnode/dappnodesdk publish patch --github_release --content_provider=http://10.200.200.7:5001 --eth_provider=https://web3.dappnode.net --variant ${{ matrix.variant }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEVELOPER_ADDRESS: "0xf35960302a07022aba880dffaec2fdd64d5bf1c1"


### PR DESCRIPTION
 The main workflow is now focused on building and testing across all supported networks for pull requests, and a separate workflow enables releases to be triggered manually. The release process now also creates a GitHub release.

**Workflow improvements:**

* The main workflow (`.github/workflows/main.yml`) is restructured to only run build and test jobs on pull request events, building all network variants instead of just mainnet. The automatic release job on push is removed.
* The previous `main_test.yml` workflow file is renamed to `release_on_demand.yml` and updated to allow manual (on-demand) releases via the GitHub Actions UI.

**Release process enhancements:**

* The manual release workflow now includes the `--github_release` flag in the publish command to automatically create a GitHub release when publishing.